### PR TITLE
Refactor TLVTree to not have a View attribute

### DIFF
--- a/application/views/helpers/Tiles.php
+++ b/application/views/helpers/Tiles.php
@@ -35,7 +35,7 @@ class Zend_View_Helper_Tiles extends Zend_View_Helper_Abstract
             $title . $badges,
             'toplevelview/show/tree',
             array(
-                'name' => $node->getRoot()->getView()->getName(),
+                'name' => $node->getRoot()->getViewName(),
                 'id'   => $node->getFullId()
             ),
             array(

--- a/application/views/helpers/Tree.php
+++ b/application/views/helpers/Tree.php
@@ -71,7 +71,7 @@ class Zend_View_Helper_Tree extends Zend_View_Helper_Abstract
             $url = Url::fromPath(
                 'toplevelview/show/tree',
                 array(
-                    'name' => $node->getRoot()->getView()->getName(),
+                    'name' => $node->getRoot()->getViewName(),
                     'id'   => $node->getFullId()
                 )
             );

--- a/library/Toplevelview/Model/View.php
+++ b/library/Toplevelview/Model/View.php
@@ -82,7 +82,8 @@ class View
         if ($this->tree === null) {
             $this->ensureParsed();
             $this->tree = $tree = TLVTree::fromArray($this->raw);
-            $tree->setView($this);
+            $tree->setViewName($this->getName());
+            $tree->setViewChecksum($this->getTextChecksum());
         }
         return $this->tree;
     }

--- a/library/Toplevelview/Tree/TLVTree.php
+++ b/library/Toplevelview/Tree/TLVTree.php
@@ -38,10 +38,9 @@ class TLVTree extends TLVTreeNode
 
     protected $cacheLifetime = 60;
 
-    /**
-     * @var View
-     */
-    protected $view;
+    protected $viewName;
+
+    protected $viewChecksum;
 
     /**
      * Return a child by its ID
@@ -70,22 +69,25 @@ class TLVTree extends TLVTreeNode
         return $currentNode;
     }
 
-    /**
-     * @return View
-     */
-    public function getView()
+    public function getViewName(): string
     {
-        return $this->view;
+        return $this->viewName;
     }
 
-    /**
-     * @param View $view
-     *
-     * @return $this
-     */
-    public function setView(View $view)
+    public function setViewName(string $name)
     {
-        $this->view = $view;
+        $this->viewName = $name;
+        return $this;
+    }
+
+    public function getViewChecksum(): string
+    {
+        return $this->viewChecksum;
+    }
+
+    public function setViewChecksum(string $checksum)
+    {
+        $this->viewChecksum = $checksum;
         return $this;
     }
 
@@ -111,12 +113,9 @@ class TLVTree extends TLVTreeNode
 
     protected function getCacheName()
     {
-        $view = $this->getView();
-        return sprintf(
-            '%s-%s.json',
-            $view->getName(),
-            $view->getTextChecksum()
-        );
+        $n = $this->getViewName();
+        $c = $this->getViewChecksum();
+        return sprintf('%s-%s.json', $n, $c);
     }
 
     protected function loadCache()

--- a/test/php/library/Toplevelview/ViewConfigTest.php
+++ b/test/php/library/Toplevelview/ViewConfigTest.php
@@ -5,6 +5,7 @@ namespace Tests\Icinga\Module\Toplevelview;
 use Icinga\Module\Toplevelview\ViewConfig;
 
 use Icinga\Exception\NotReadableError;
+use Icinga\Exception\NotFoundError;
 use PHPUnit\Framework\TestCase;
 
 final class ViewConfigTest extends TestCase
@@ -30,5 +31,16 @@ final class ViewConfigTest extends TestCase
         $clone = clone $view;
         $this->assertSame(null, $clone->getName());
         $this->assertFalse($clone->hasBeenLoaded());
+    }
+
+    public function testViewConfigWithTree()
+    {
+        $this->expectException(NotFoundError::class);
+
+        $c = new ViewConfig('test/testdata');
+        $view = $c->loadByName('example');
+
+        $t = $view->getTree();
+        $t->getById('0-1-2');
     }
 }


### PR DESCRIPTION
Reasoning: The mental model was a bit confusing, since the Model\View reads the YAML and has a Tree attribute, while this Tree had the same View as attribute.

But we only need some attributes from the View in the Tree, might even be possible to use Model\View instead of Tree in some cases and then use view->getTree().