### PR TITLE
Validate filenames before trying to store them

### DIFF
--- a/library/Toplevelview/Model/View.php
+++ b/library/Toplevelview/Model/View.php
@@ -234,6 +234,22 @@ class View
     }
 
     /**
+     * validateName validates the name of the view.
+     * This can be used to ensure the YAML files have proper/expected names
+     * @return bool
+     */
+    public function validateName(): bool
+    {
+        if (empty($this->name)) {
+            return false;
+        }
+        if (preg_match('/[!@#\$%^&*\/\\\()]/', $this->name)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * getName returns the name of this View
      * @return ?string
      */

--- a/library/Toplevelview/ViewConfig.php
+++ b/library/Toplevelview/ViewConfig.php
@@ -242,10 +242,18 @@ class ViewConfig
     /**
      * storeToSession stores a View's text to the user's session
      *
+     * @throws NotWritableError if the data cannot be stored
+     * @throws SecurityException if the user has no access to edit
+     *
      * @param $view
      */
     public function storeToSession($view): void
     {
+        // Assert the name is valid, to avoid tricky filenames such as '../../view'
+        if (!$view->validateName()) {
+            throw new NotWritableError('Invalid filename: %s', $view->getName());
+        }
+
         // Assert the user has rights to edit this view
         $restrictions = $this->getRestrictions('toplevelview/filter/edit');
         $this->assertAccessToView($restrictions, $view->getName());
@@ -266,10 +274,18 @@ class ViewConfig
     /**
      * storeToFile stores a View to its configuration file
      *
+     * @throws NotWritableError if the data cannot be stored
+     * @throws SecurityException if the user has no access to edit
+     *
      * @param $view
      */
     public function storeToFile($view): void
     {
+        // Assert the name is valid, to avoid tricky filenames such as '../../view'
+        if (!$view->validateName()) {
+            throw new NotWritableError('Invalid filename: %s', $view->getName());
+        }
+
         // Assert the user has rights to edit this file
         $restrictions = $this->getRestrictions('toplevelview/filter/edit');
         $this->assertAccessToView($restrictions, $view->getName());

--- a/test/php/library/Toplevelview/Model/ViewTest.php
+++ b/test/php/library/Toplevelview/Model/ViewTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Icinga\Module\Toplevelview;
+
+use Icinga\Module\Toplevelview\Model\View;
+
+use PHPUnit\Framework\TestCase;
+
+final class ViewTest extends TestCase
+{
+    public function testViewValidateName()
+    {
+        $v = new View('myview', 'yml');
+        $this->assertSame('myview', $v->getName());
+
+        $tests = [
+            'example' => true,
+            'Example' => true,
+            'ex_ample' => true,
+            'ex_am-ple' => true,
+            '1ex_am-ple2' => true,
+            'Ex_a2m-ple123' => true,
+            '1ex_am-ple2' => true,
+            'example.yaml' => true,
+            'e#x(_)am_123-ple' => false,
+            'ex/ample' => false,
+            'ex\ample' => false,
+            '' => false,
+            'Филе' => true,
+            '😺' => true,
+            '../../example' => false
+        ];
+
+        foreach ($tests as $name => $value) {
+            $v->setName($name);
+            $this->assertSame($v->validateName(), $value);
+        }
+    }
+}


### PR DESCRIPTION
 - Avoids path traversal issues with e.g. `../../viewname`