### PR TITLE
Make the badge and tile color independent from eachother

### DIFF
--- a/application/views/helpers/Badges.php
+++ b/application/views/helpers/Badges.php
@@ -28,7 +28,7 @@ class Zend_View_Helper_Badges extends Zend_View_Helper_Abstract
             if ($value !== null && $value > 0) {
                 $values = true;
                 $title = $value . ' ' . Str::prettyTitle($key);
-                $class = 'tlv-status-tile ' . str_replace('_', ' ', $key);
+                $class = 'tlv-status-badge ' . str_replace('_', ' ', $key);
                 $htm .= sprintf(
                     '<div class="badge status-badge %s" title="%s">%s</div>',
                     $class,

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -59,6 +59,57 @@
 }
 
 .tlv-status-tile {
+  &.critical, &.down {
+    background-color: @tlv-color-critical-bg;
+    color: @tlv-color-critical-fg;
+  }
+  &.critical.handled, &.down.handled {
+    background-color: fade(@tlv-color-critical-handled-bg, 50%);
+    color: @tlv-color-critical-handled-fg;
+  }
+  &.unknown, &.unreachable {
+    background-color: @tlv-color-unknown-bg;
+    color: @tlv-color-unknown-fg;
+  }
+  &.unknown.handled, &.unreachable.handled {
+    background-color: fade(@tlv-color-unknown-handled-bg, 50%);
+    color: @tlv-color-unknown-handled-fg;
+  }
+  &.warning {
+    background-color: @tlv-color-warning-bg;
+    color: @tlv-color-warning-fg;
+  }
+  &.warning.handled {
+    background-color: fade(@tlv-color-warning-handled-bg, 50%);
+    color: @tlv-color-warning-handled-fg;
+  }
+  &.ok, &.up {
+    background-color: @tlv-color-ok-bg;
+    color: @tlv-color-ok-fg;
+  }
+  &.downtime.active {
+    background-color: @tlv-color-downtime-bg;
+    color: @tlv-color-downtime-fg;
+  }
+  &.downtime.handled {
+    background-color: @tlv-color-downtime-handled-bg;
+    color: @tlv-color-downtime-handled-fg;
+  }
+  &.pending {
+    background-color: @tlv-color-pending-bg;
+    color: @tlv-color-pending-fg;
+  }
+  &.missing {
+    background-color: @tlv-color-missing-bg;
+    color: @tlv-color-missing-fg;
+  }
+  &.total {
+    background-color: @icinga-blue;
+    color: @text-color-on-icinga-blue;
+  }
+}
+
+.tlv-status-badge {
   .badges {
     .badge {
       border: 0.1em solid @white;


### PR DESCRIPTION
This PR makes the badge and tile color independent from each other. So the badges can still have the full warn,crit,unkown color and the tile can be colored differently. 

It also changes the default handled color to be more faded.
 
<img width="1117" height="228" alt="screenshot_2026-06-11-124759" src="https://github.com/user-attachments/assets/b1a29cc9-f285-4bac-bc4d-540bfab3d913" />
